### PR TITLE
Splunk: Avoid indexing Rackspace health checks

### DIFF
--- a/ops/roles/admin/tasks/main.yml
+++ b/ops/roles/admin/tasks/main.yml
@@ -1,4 +1,3 @@
 ---
-- include: python.yml
 - include: cloudfiles.yml
 - include: keter.yml

--- a/ops/roles/splunk/tasks/main.yml
+++ b/ops/roles/splunk/tasks/main.yml
@@ -27,6 +27,12 @@
 - name: Open up port for management
   command: ufw allow {{ splunk_indexer_management_port }}/tcp
 
+- name: Add custom `props.conf`
+  template: src=props.conf dest=/opt/splunk/etc/system/local/props.conf
+
+- name: Add custom `transforms.conf`
+  template: src=transforms.conf dest=/opt/splunk/etc/system/local/transforms.conf
+
 - name: Start Splunk
   command: /opt/splunk/bin/splunk start
          --accept-license --answer-yes --auto-ports --no-prompt

--- a/ops/roles/splunk/templates/props.conf
+++ b/ops/roles/splunk/templates/props.conf
@@ -1,0 +1,5 @@
+[source::/var/log/zoomhub/zoomhub.log]
+TRANSFORMS-null= rackspaceHealthChecksApache
+
+[source::/opt/keter/log/app-zoomhub/current.log]
+TRANSFORMS-null= rackspaceHealthChecksJSON

--- a/ops/roles/splunk/templates/transforms.conf
+++ b/ops/roles/splunk/templates/transforms.conf
@@ -1,0 +1,9 @@
+[rackspaceHealthChecksApache]
+REGEX = GET\s+\/health
+DEST_KEY = queue
+FORMAT = nullQueue
+
+[rackspaceHealthChecksJSON]
+REGEX = "path":\s+"\/health"
+DEST_KEY = queue
+FORMAT = nullQueue


### PR DESCRIPTION
@davestern, @matthew-cox: I assume you figured this out, but if not, the following worked for me to filter out specific events (send them to `nullQueue` which is Splunk’s `/dev/null`) to avoid license overages.

Docs: http://docs.splunk.com/Documentation/Splunk/6.1.3/Forwarding/Routeandfilterdatad#Discard_specific_events_and_keep_the_rest